### PR TITLE
fix(OSPO-13): update template documentation

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -1,6 +1,6 @@
 # Acknowledgements
 
-**Repository:** `[archetypes]`  
+**Repository:** `ospo-resources`  
 **Description:** `Recognises suppliers, partner organisations, and other contributors to the repository’s development.`  
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 
@@ -10,12 +10,7 @@ The National Digital Twin Programme (NDTP) would like to acknowledge the contrib
 
 Over time, the following organisations have provided technical expertise, development support, and domain knowledge that have contributed to the evolution of this project:
 
-i.e. 
-- [Supplier A]
-- [Supplier B]
-- [Supplier C]
-- [Supplier D]
-(etc.)
+- Informed Solutions
 
 <!--
 

--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,7 +1,7 @@
 # Open-Source Compliance & Code Audit Report 
 # SPDX-License-Identifier: OGL-UK-3.0 
 
-**Repository:** `[archetypes]`   
+**Repository:** `ospo-resources`   
 **Date of Last Audit:** `[YYYY-MM-DD]`   
 **Reviewed By:** `[NDTP Supplier]`   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-**Repository:** `[archetypes]`  
+**Repository:** `ospo-resources`  
 **Description:** `Tracks all notable changes, version history, and roadmap toward 1.0.0 following Semantic Versioning.`  
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 
@@ -17,54 +17,14 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 
 ---
 
-## [Unreleased] 
+## [0.1.0] – 2025-06-23 
 
-### Added 
-- Placeholder for upcoming features and enhancements. 
+### Initial Repository Creation
 
-### Fixed 
-- Placeholder for bug fixes and security updates. 
-
-### Changed 
-- Placeholder for changes to existing functionality. 
-
----
-
-## [0.90.0] – YYYY-MM-DD 
-
-### Initial Public Release (Pre-Stable) 
-
-This is the first public release of this repository under NDTP's open-source governance model. 
-Since this release is **pre-1.0.0**, changes may still occur that are **not fully backward-compatible**. 
+Initial repository creation and configuration.
 
 #### Initial Features 
-- Key functionality for [feature/module name]. 
-- Implementation of [API/component name]. 
-- Documentation and onboarding guidance. 
-
-#### Known Limitations 
-- Some components are subject to change before `1.0.0`. 
-- APIs may evolve based on partner feedback and internal testing. 
-
----
-
-## [0.90.1] – YYYY-MM-DD 
-
-### Fixed 
-- Security patch addressing [issue]. 
-- Minor bug fix in [module]. 
-
----
-
-## [0.91.0] – YYYY-MM-DD 
-
-### Added 
-- New feature: [Feature name]. 
-
-### Changed 
-- Adjusted API contracts for [component]. 
-
----
+-  Addition of reusable GitHub Actions workflows.
 
 ## Future Roadmap to `1.0.0` 
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of Conduct 
 
-**Repository:** `[archetypes]`   
+**Repository:** `ospo-resources`   
 **Description:** `Defines expected behaviors, rules, and the enforcement process to ensure professional engagement.`   
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines  
 
-**Repository:** `[archetypes]`  
+**Repository:** `ospo-resources`  
 **Description:** `Guidelines for issue reporting, documentation suggestions, and NDTP’s controlled contribution model.`  
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Maintainers  
 
-**Repository:** `[archetypes]`  
+**Repository:** `ospo-resources`  
 **Description:** `Lists maintainers responsible for reviewing issues, security, and documentation updates.`  
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 
@@ -32,9 +32,9 @@ NDTP does not accept public code contributions, but we welcome **bug reports and
 
 | Name              | Organisation           | Role               | Contact                |
 |-------------------|------------------------|--------------------|------------------------|
-| [Maintainer Name] | [NDTP / Supplier Name] | Lead Maintainer    | [email@example.com]    |
-| [Maintainer Name] | [NDTP / Supplier Name] | Security Contact   | [security@example.com] |
-| [Maintainer Name] | [NDTP / Supplier Name] | Documentation Lead | [docs@example.com]     |
+| [Maintainer Name] | [NDTP / Supplier Name] | Lead Maintainer    | [NDTP-OSS@informed.com]|
+| [Maintainer Name] | [NDTP / Supplier Name] | Security Contact   | [NDTP-OSS@informed.com]|
+| [Maintainer Name] | [NDTP / Supplier Name] | Documentation Lead | [NDTP-OSS@informed.com]|
 
 For general issues, please **open a GitHub issue** rather than contacting maintainers directly.  
 
@@ -68,7 +68,7 @@ GUIDANCE: USE THIS IN PLACE OF THE ABOVE IF THE REPOSITORY IS IN TRANSITION. PLE
 
 # Maintainers  
 
-**Repository:** `[archetypes]`  
+**Repository:** `ospo-resources`  
 **Description:** `Lists maintainers responsible for reviewing issues, security, and documentation updates.`  
 **SPDX-License-Identifier: OGL-UK-3.0
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,6 +1,6 @@
 # NOTICE  
 
-**Repository:** `[archetypes]`    
+**Repository:** `ospo-resources`    
 **Description:** `Attribution and legal notices related to the use of this repository, including acknowledgments of external contributions.`    
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 

--- a/OGL_LICENCE.md
+++ b/OGL_LICENCE.md
@@ -1,6 +1,6 @@
 # Open Government Licence v3.0 
 
-**Repository:** `[archetypes]`  
+**Repository:** `ospo-resources`  
 **Description:** `Covers all documentation files in this repository that are released under the Open Government Licence v3.0.`  
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-**Repository:** `[archetypes]`  
+**Repository:** `ospo-resources`  
 **Description:** `Details the responsible disclosure process for security vulnerabilities.`  
 **SPDX-License-Identifier:** `OGL-UK-3.0`  
 


### PR DESCRIPTION
### Type of Change

Documentation corrections.

### Description 

Updates template documentation inherited from Archectypes repository.

### Checklist
- [ ] Test code against a test environment and not just on a local cluster 
- [X] Reference relevant issue(s) where applicable and close them after merging
- [X] Update any documentation and relevant `CHANGELOG.md` files