### PR TITLE
feat(OSPO-28): remove need for access token when cloning repository

### DIFF
--- a/.github/workflows/synchronise-ospo-workflows.yml
+++ b/.github/workflows/synchronise-ospo-workflows.yml
@@ -18,16 +18,6 @@ jobs:
           app-id: ${{ secrets.OSPO_WORKFLOW_APP_ID }}
           private-key: ${{ secrets.OSPO_WORKFLOW_PRIVATE_KEY }}
 
-      - name: Fetch GitHub App token for OSPO source repo (read-only)
-        id: ospo_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OSPO_WORKFLOW_APP_ID }}
-          private-key: ${{ secrets.OSPO_WORKFLOW_PRIVATE_KEY }}
-          owner: National-Digital-Twin
-          repositories: ospo-resources
-          permission-contents: read
-
       - name: Checkout target repository
         uses: actions/checkout@v4
         with:
@@ -38,7 +28,6 @@ jobs:
         with:
           repository: National-Digital-Twin/ospo-resources
           path: ospo-resources
-          token: ${{ steps.ospo_token.outputs.token }}
 
       - name: Copy and compare workflow files from OSPO repo
         run: |


### PR DESCRIPTION
### Type of Change
Enhancement

### Description 
With this repository now being public, fetching a token to authenticate is no longer required.

### Checklist
- [ ] Test code against a test environment and not just on a local cluster 
- [X] Reference relevant issue(s) where applicable and close them after merging
- [ ] Update any documentation and relevant `CHANGELOG.md` files