### PR TITLE
fix(OSPO): skip OSPO workflow synchronisation for dependabot PRs

### DIFF
--- a/.github/workflows/synchronise-ospo-workflows.yml
+++ b/.github/workflows/synchronise-ospo-workflows.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   synchronise-ospo-workflows:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 
 ---
 
+## [0.90.1] – 2025-07-11 
+
+### Fixed 
+- Skip OSPO workflow synchronisation job for pull requests raised by Dependabot.
+
 ## [0.90.0] – 2025-06-23 
 
 ### Initial public release

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This repository has been developed with public funding as part of the National D
 
 ## License  
 This repository contains both source code and documentation, which are covered by different licenses:  
-- **Code:** Originally developed by the National Digital Twin Programme Open-Source Promgram Office for the National Digital Twin Programme. Licensed under the [Apache License 2.0](./LICENSE.md).  
+- **Code:** Originally developed by the National Digital Twin Programme Open-Source Program Office for the National Digital Twin Programme. Licensed under the [Apache License 2.0](./LICENSE.md).  
 - **Documentation:** Licensed under the [Open Government Licence v3.0](./OGL_LICENCE.md).  
 See `LICENSE.md`, `OGL_LICENCE.md`, and `NOTICE.md` for details.  
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This repository has been developed with public funding as part of the National D
 
 ## License  
 This repository contains both source code and documentation, which are covered by different licenses:  
-- **Code:** Originally developed by the National Digital Twin Programme Open-Source Project Office for the National Digital Twin Programme. Licensed under the [Apache License 2.0](./LICENSE.md).  
+- **Code:** Originally developed by the National Digital Twin Programme Open-Source Promgram Office for the National Digital Twin Programme. Licensed under the [Apache License 2.0](./LICENSE.md).  
 - **Documentation:** Licensed under the [Open Government Licence v3.0](./OGL_LICENCE.md).  
 See `LICENSE.md`, `OGL_LICENCE.md`, and `NOTICE.md` for details.  
 


### PR DESCRIPTION
### Type of Change
Bug fix

### Description 
Skips OSPO workflow synchronisation job when pull requests are raised by dependabot. Currently, dependabot cannot access the GitHub Application identity, which causes the workflow to fail (due to https://github.com/actions/create-github-app-token/issues/249).

### Checklist
- [ ] Test code against a test environment and not just on a local cluster 
- [ ] Reference relevant issue(s) where applicable and close them after merging
- [X] Update any documentation and relevant `CHANGELOG.md` files