### PR TITLE
fix(OSPO): correct semver ignore major strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 
 ---
 
+## [0.91.2] – 2025-07-28
+
+### Fixed 
+- Correct how dependabot helper tool ignores semver major updates if opted out.
+
 ## [0.91.1] – 2025-07-16
 
 ### Fixed 

--- a/tools/dependabot-configuration-helper/dependabot-configuration-helper.sh
+++ b/tools/dependabot-configuration-helper/dependabot-configuration-helper.sh
@@ -69,6 +69,7 @@ add_dependabot_ecosystem() {
     target-branch: "$target_branch"
     schedule:
       interval: "$frequency"
+    versioning-strategy: "increase"
     groups:
       $group:
         patterns:
@@ -77,9 +78,10 @@ EOF
 
   if [[ "$allow_major" == "no" ]]; then
     cat >> "$output_file" <<EOF
+    ignore:
+      - dependency-name: "*"
         update-types:
-          - "minor"
-          - "patch"
+          - "version-update:semver-major"
 EOF
   fi
 }
@@ -103,7 +105,7 @@ filtered_find() {
 
 # GitHub Actions
 if [ -d ".github/workflows" ]; then
-  add_dependabot_ecosystem "github-actions" "/" "actions-updates"
+  add_dependabot_ecosystem "github-actions" "/" "actions-dependencies"
 fi
 
 # Python: requirements.txt, pyproject.toml, Pipfile

--- a/tools/dependabot-configuration-helper/dependabot-configuration-helper.sh
+++ b/tools/dependabot-configuration-helper/dependabot-configuration-helper.sh
@@ -69,7 +69,6 @@ add_dependabot_ecosystem() {
     target-branch: "$target_branch"
     schedule:
       interval: "$frequency"
-    versioning-strategy: "increase"
     groups:
       $group:
         patterns:


### PR DESCRIPTION
### Type of Change
Bug fix.

### Description 
Corrects behaviour for ignoring semver major updates, rather than them being captured in a separate group.

### Checklist
- [X] Test code against a test environment and not just on a local cluster 
- [ ] Reference relevant issue(s) where applicable and close them after merging
- [X] Update any documentation and relevant `CHANGELOG.md` files