### PR TITLE
fix(OSPO): skip sonar scans if dependabot PR raised

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,7 @@ jobs:
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
-        if: always()
+        if: github.actor != 'dependabot[bot]'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 - **Build metadata** – If needed, use `+build` (e.g., `2.1.0+20250314`).
 
 ---
+## [0.99.2] - 2026-06-04
+
+### Update
+
+- skip sonar scan if dependabot pull request raised to preserve action minutes usage
+
 ## [0.99.1] - 2026-05-28
 
 ### Update


### PR DESCRIPTION
### Type of Change
Enhancement 

### Description 
When Dependabot raises pull requests, the structure of the codebase is not itself changed (just dependency versions). As such, a sonar scan is surplus to requirement. This change skips sonar scanning if the actor is explicitly recognised as dependabot to preserve compute usage.

### Checklist
- [X] Test code against a test environment and not just on a local cluster 
- [ ] Reference relevant issue(s) where applicable and close them after merging
- [X] Update any documentation and relevant `CHANGELOG.md` files